### PR TITLE
Make script faster in two ways

### DIFF
--- a/8mb
+++ b/8mb
@@ -15,6 +15,8 @@ ffmpeg \
 	-loglevel error \
 	-i "$fileInput" \
 	-b ${bitrate}k \
+	-cpu-used 6 \
+	-c:a copy \
 	$fileOutput
 afterSizeBytes=$(stat --printf="%s" $fileOutput)
 shrinkPercentage=$(($beforeSizeBytes / $afterSizeBytes))


### PR DESCRIPTION
1. Leverage FFMPEG's acceleration by using the flag 'cpu-used 6'
2. Copy the audio stream which doesn't need to be transcoded